### PR TITLE
Fix link to Network Tool MSDN blog entry

### DIFF
--- a/docs/profiling/network-usage.md
+++ b/docs/profiling/network-usage.md
@@ -22,7 +22,7 @@ The Visual Studio **Network** diagnostics tool collects data about network opera
  The Network tool supports only UWP apps. Other platforms are not supported at this time.  
   
 > [!NOTE]
->  For a more complete description of the Network tool, see [Introducing Visual Studio's network tool](http://blogs.msdn.com/b/visualstudio/archive/2015/05/04/introducing-visual-studio-s-network-tool.aspx).  
+>  For a more complete description of the Network tool, see [Introducing Visual Studio's network tool](http://blogs.msdn.com/b/visualstudio/archive/2015/05/04/introducing-visual-studios-network-tool.aspx).  
   
 ## Collecting network tool data  
  You should run the **Network** tool with an open Visual Studio project on the Visual Studio computer.  


### PR DESCRIPTION
Just using the GitHub text editor, but not sure why there's an edit to line 79...